### PR TITLE
EC-724 Provide git SHA for policy sources

### DIFF
--- a/gather/oci/go.mod
+++ b/gather/oci/go.mod
@@ -9,13 +9,15 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
@@ -36,4 +38,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require github.com/google/go-cmp v0.6.0 // indirect
+require (
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/stretchr/testify v1.9.0
+)

--- a/gather/oci/go.sum
+++ b/gather/oci/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
 github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
-github.com/enterprise-contract/go-gather/metadata/oci v0.0.1 h1:12hqwNYsvo49UOu5P+YjwDX3f0q93fUfUcY9p0u5ta4=
-github.com/enterprise-contract/go-gather/metadata/oci v0.0.1/go.mod h1:kJSMxYth37g604Cvsa18ibgTU33zagsadeQ7p1DYIak=
 github.com/enterprise-contract/go-gather/metadata/oci v0.0.2 h1:FkXQTKnGr5Hci+4mrfXJLhmjMqHTJvgtubVsFB3KgJI=
 github.com/enterprise-contract/go-gather/metadata/oci v0.0.2/go.mod h1:kJSMxYth37g604Cvsa18ibgTU33zagsadeQ7p1DYIak=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -50,8 +48,6 @@ github.com/spf13/cast v1.6.0 h1:GEiTHELF+vaR5dhz3VqZfFSzZjYbgeKDpBxQVS4GYJ0=
 github.com/spf13/cast v1.6.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=
-github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMVB+yk=
 github.com/spf13/viper v1.19.0 h1:RWq5SEjt8o25SROyN3z2OrDB9l7RPd3lwTWU8EcEdcI=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/gather/oci/oci.go
+++ b/gather/oci/oci.go
@@ -36,6 +36,8 @@ import (
 	"github.com/enterprise-contract/go-gather/metadata/oci"
 )
 
+var orasCopy = oras.Copy
+
 // OCIGatherer is a struct that implements the Gatherer interface
 // and provides methods for gathering from OCI.
 type OCIGatherer struct{}
@@ -87,7 +89,7 @@ func (f *OCIGatherer) Gather(ctx context.Context, source, destination string) (m
 	defer fileStore.Close()
 
 	// Copy the artifact to the file store
-	a, err := oras.Copy(ctx, src, repo, fileStore, "", oras.DefaultCopyOptions)
+	a, err := orasCopy(ctx, src, repo, fileStore, "", oras.DefaultCopyOptions)
 	if err != nil {
 		return nil, fmt.Errorf("pulling policy: %w", err)
 	}

--- a/metadata/oci/oci.go
+++ b/metadata/oci/oci.go
@@ -9,3 +9,8 @@ func (o OCIMetadata) Get() map[string]any {
 		"digest": o.Digest,
 	}
 }
+
+// GetDigest returns the digest of the artifact.
+func (o OCIMetadata) GetDigest() string {
+	return o.Digest
+}

--- a/metadata/oci/oci_test.go
+++ b/metadata/oci/oci_test.go
@@ -1,0 +1,26 @@
+package oci
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOCIMetadata_Get(t *testing.T) {
+	o := OCIMetadata{Digest: "fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"}
+	expected := map[string]any{
+		"digest": "fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+	}
+	result := o.Get()
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected Get() to return %v, but got %v", expected, result)
+	}
+}
+
+func TestOCIMetadata_GetDigest(t *testing.T) {
+	o := OCIMetadata{Digest: "fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"}
+	expected := "fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"
+	result := o.GetDigest()
+	assert.Equal(t, expected, result, "Expected GetDigest() to return %s, but got %s", expected, result)
+}


### PR DESCRIPTION
This commit adds functionality to return the digest for the object being gathered via OCIGatherer. This digest is available in the oci metadata struct returned from calling `oci.Gather` or via the `GetDigest()` method in the metadata/oci package.