### PR TITLE
EC-863 failure to download policy from local paths

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -209,7 +209,7 @@ func (f *FileGatherer) copyDirectory(ctx context.Context, source, destination st
 					}
 					defer srcFile.Close()
 
-					saver, err := saver.NewSaver(dst.Scheme)
+					saver, err := saver.NewSaver("file")
 					if err != nil {
 						errChan <- err
 						return


### PR DESCRIPTION
This commit fixes the bug encountered in EC-863. The root issue is due to calling `url.Parse()` on paths such as `/path/to/policy`. The resulting `.Scheme()` call returns an empty string.

The fix is to explicitly pass the `"file"` string to the `saver.NewSaver()` call.