### PR TITLE
EC-863 add explicit "file" to saver.NewSaver()

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -120,7 +120,7 @@ func (f *FileGatherer) copyFile(ctx context.Context, source, destination string)
 	}
 
 	// Create the appropriate Saver to handle storing the data.
-	saver, err := saver.NewSaver(destFile.Scheme)
+	saver, err := saver.NewSaver("file")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create saver: %w", err)
 	}


### PR DESCRIPTION
This commit explicitly passes the expected scheme ("file") to the saver.NewSaver() call in copyFile() in the gather/file package.