### PR TITLE
Fix: call ClassifyURI on destinations in copyFile

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -36,6 +36,7 @@ import (
 	"github.com/enterprise-contract/go-gather/metadata"
 	"github.com/enterprise-contract/go-gather/metadata/file"
 	"github.com/enterprise-contract/go-gather/saver"
+	utils "github.com/enterprise-contract/go-gather"
 )
 
 // FileGatherer is a struct that implements the Gatherer interface
@@ -112,6 +113,18 @@ func (f *FileGatherer) copyFile(ctx context.Context, source, destination string)
 		return nil, fmt.Errorf("failed to open source file: %w", err)
 	}
 	defer srcFile.Close()
+
+	// Classify the destination to ensure no problems with the path.
+	destType,err := utils.ClassifyURI(destination)
+	if err != nil {
+		return nil, fmt.Errorf("failed to classify destination URI: %w", err)
+	}
+	if destType == utils.Unknown{
+		return nil, fmt.Errorf("failed to parse destination URI: parse \"%s\": unknown protocol scheme", destination)
+	}
+	if destType != utils.FileURI {
+		return nil, fmt.Errorf("destination URI is not a file")
+	}
 
 	// Parse the destination URI.
 	destFile, err := url.Parse(destination)

--- a/gather/file/file_test.go
+++ b/gather/file/file_test.go
@@ -214,7 +214,7 @@ func TestFileGatherer_copyFile_Destination_URIParseError(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error, but got nil")
 	}
-	if err.Error() != "failed to parse destination URI: parse \":\": missing protocol scheme" {
+	if err.Error() != "failed to parse destination URI: parse \":\": unknown protocol scheme" {
 		t.Logf("Expected: %s, Got: %s", "failed to parse destination URI: parse \":\": missing protocol scheme", err.Error())
 		t.Fail()
 	}
@@ -251,8 +251,8 @@ func TestFileGatherer_copyFile_CreateSaverError(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error, but got nil")
 	}
-	if err.Error() != "failed to create saver: unsupported protocol: ftp" {
-		t.Logf("Expected: %s, Got: %s", "failed to create saver: unsupported protocol: ftp", err.Error())
+	if err.Error() != "failed to classify destination URI: unsupported protocol: ftp" {
+		t.Logf("Expected: %s, Got: %s", "failed to classify destination URI: unsupported protocol: ftp", err.Error())
 		t.Fail()
 	}
 


### PR DESCRIPTION
This commit implements a call to the ClassifyURI function to ensure that the destination is a FileURI type in the copyFile function.