### PR TITLE
EC-908 Add GetPinnedURL for metadata types.

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -32,11 +32,11 @@ import (
 	"sync"
 	"time"
 
+	utils "github.com/enterprise-contract/go-gather"
 	"github.com/enterprise-contract/go-gather/expander"
 	"github.com/enterprise-contract/go-gather/metadata"
 	"github.com/enterprise-contract/go-gather/metadata/file"
 	"github.com/enterprise-contract/go-gather/saver"
-	utils "github.com/enterprise-contract/go-gather"
 )
 
 // FileGatherer is a struct that implements the Gatherer interface
@@ -115,11 +115,11 @@ func (f *FileGatherer) copyFile(ctx context.Context, source, destination string)
 	defer srcFile.Close()
 
 	// Classify the destination to ensure no problems with the path.
-	destType,err := utils.ClassifyURI(destination)
+	destType, err := utils.ClassifyURI(destination)
 	if err != nil {
 		return nil, fmt.Errorf("failed to classify destination URI: %w", err)
 	}
-	if destType == utils.Unknown{
+	if destType == utils.Unknown {
 		return nil, fmt.Errorf("failed to parse destination URI: parse \"%s\": unknown protocol scheme", destination)
 	}
 	if destType != utils.FileURI {

--- a/gather/file/go.mod
+++ b/gather/file/go.mod
@@ -3,6 +3,7 @@ module github.com/enterprise-contract/go-gather/gather/file
 go 1.22.5
 
 require (
+	github.com/enterprise-contract/go-gather v0.0.3
 	github.com/enterprise-contract/go-gather/expander v0.0.1
 	github.com/enterprise-contract/go-gather/metadata v0.0.2
 	github.com/enterprise-contract/go-gather/metadata/file v0.0.1

--- a/gather/file/go.sum
+++ b/gather/file/go.sum
@@ -1,11 +1,11 @@
+github.com/enterprise-contract/go-gather v0.0.3 h1:Qh4CJhOPdMit4Z/BK3rv7S3GkZ5XLzAlAus1eMKLDA4=
+github.com/enterprise-contract/go-gather v0.0.3/go.mod h1:gXqnYRW9uTD06xli3pE+9cwtPVcIdqyPIqBcKQ+kK8I=
 github.com/enterprise-contract/go-gather/expander v0.0.1 h1:CRJX7crqNyuuo82DtFbyIpJB/2hV62zWof4t1dOmCC0=
 github.com/enterprise-contract/go-gather/expander v0.0.1/go.mod h1:bZ7oijDzlpY3gGc+H48YSsxbCEGxmsqQj+PxnYjtrjg=
 github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
 github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
 github.com/enterprise-contract/go-gather/metadata/file v0.0.1 h1:DRhTGKRXFRh/FVn2LNX8yIJZHHYKc5x5260hnYxQ4DY=
 github.com/enterprise-contract/go-gather/metadata/file v0.0.1/go.mod h1:4PckwLejZstUEBp2QUAdQYQ0O+h5tijrs48j+7OY4OY=
-github.com/enterprise-contract/go-gather/saver v0.0.1 h1:f+oHdg83kwbVDqIs6Or9BatytNKm+ISO9ChztDcnqXA=
-github.com/enterprise-contract/go-gather/saver v0.0.1/go.mod h1:uOt8X/CztOGi0YC5jERopBQpjXqkU6UPUqPellgBBG8=
 github.com/enterprise-contract/go-gather/saver v0.0.2 h1:+XeeuEzglzBxlTRD0boIqac7v4zI7g2g2es74iVTXgM=
 github.com/enterprise-contract/go-gather/saver v0.0.2/go.mod h1:3f37v+I/EY8me7gaopGly107R7gqibR8UyBA3NgzMbo=
 github.com/enterprise-contract/go-gather/saver/file v0.0.1 h1:rLDMb7AW5kJLqRaKXazZroT8wfqy43tth6O6XLKY0MY=

--- a/gather/go.sum
+++ b/gather/go.sum
@@ -31,8 +31,8 @@ github.com/enterprise-contract/go-gather/expander v0.0.1 h1:CRJX7crqNyuuo82DtFby
 github.com/enterprise-contract/go-gather/expander v0.0.1/go.mod h1:bZ7oijDzlpY3gGc+H48YSsxbCEGxmsqQj+PxnYjtrjg=
 github.com/enterprise-contract/go-gather/gather/file v0.0.1 h1:UOec5Gc7+Q9u3x0Cyw8l2JDYCH7RTtHVnC57Rqs0Nyg=
 github.com/enterprise-contract/go-gather/gather/file v0.0.1/go.mod h1:tHsShLa5XpNSZbH8paHZR3Ltgu/7wtxpdCTVP8EXk/U=
-github.com/enterprise-contract/go-gather/gather/git v0.0.4 h1:UcQkvq2Cm7MFONvtECoNIbPe1R85+xraJRungQym78o=
-github.com/enterprise-contract/go-gather/gather/git v0.0.4/go.mod h1:8pSBY25NpofcTrEsnmRv4h1s30ukwkgFwew1iA19Fnc=
+github.com/enterprise-contract/go-gather/gather/git v0.0.5 h1:fWz0D42Lv2AjKkQCTfv+i5bJOOVD0RusaLTJuGfcIvc=
+github.com/enterprise-contract/go-gather/gather/git v0.0.5/go.mod h1:jEtaBsc8a4AsbXRwZaDPQAW9t5bNU/GvwNgYLAgwDhE=
 github.com/enterprise-contract/go-gather/gather/http v0.0.2 h1:Cwx+R2ECbpFZlYDD62h5lRrV/zyspxt2TOuWH8HlqYE=
 github.com/enterprise-contract/go-gather/gather/http v0.0.2/go.mod h1:Vdghi2YICVhShDK/MuTlZIrVvh0mBQrhKlstoENWrwM=
 github.com/enterprise-contract/go-gather/gather/oci v0.0.4 h1:THirSwb3gkBWJgJjOTzHhw5kbhSRqjClfGau9RW5uFc=

--- a/gather/http/go.sum
+++ b/gather/http/go.sum
@@ -7,8 +7,6 @@ github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPm
 github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
 github.com/enterprise-contract/go-gather/metadata/http v0.0.1 h1:ebhT9h93v/Et+5c1t5PJzGj6V2g18elm1VDrQg6y63A=
 github.com/enterprise-contract/go-gather/metadata/http v0.0.1/go.mod h1:VjjTqsJ+sM7MVsVkEFgpcJzY9hur9pIBEMptrVvAwoI=
-github.com/enterprise-contract/go-gather/saver v0.0.1 h1:f+oHdg83kwbVDqIs6Or9BatytNKm+ISO9ChztDcnqXA=
-github.com/enterprise-contract/go-gather/saver v0.0.1/go.mod h1:uOt8X/CztOGi0YC5jERopBQpjXqkU6UPUqPellgBBG8=
 github.com/enterprise-contract/go-gather/saver v0.0.2 h1:+XeeuEzglzBxlTRD0boIqac7v4zI7g2g2es74iVTXgM=
 github.com/enterprise-contract/go-gather/saver v0.0.2/go.mod h1:3f37v+I/EY8me7gaopGly107R7gqibR8UyBA3NgzMbo=
 github.com/enterprise-contract/go-gather/saver/file v0.0.1 h1:rLDMb7AW5kJLqRaKXazZroT8wfqy43tth6O6XLKY0MY=

--- a/metadata/file/file.go
+++ b/metadata/file/file.go
@@ -41,6 +41,7 @@
 package file
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -66,10 +67,24 @@ func (m *FileMetadata) Get() map[string]any {
 	}
 }
 
+func (m FileMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	return u, nil
+}
+
 func (m *DirectoryMetadata) Get() map[string]any {
 	return map[string]any{
 		"size":      m.Size,
 		"path":      m.Path,
 		"timestamp": m.Timestamp,
 	}
+}
+
+func (m DirectoryMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty file path")
+	}
+	return u, nil
 }

--- a/metadata/file/file_test.go
+++ b/metadata/file/file_test.go
@@ -81,3 +81,80 @@ func TestDirectoryMetadata_Get(t *testing.T) {
 		}
 	}
 }
+
+func TestFileMetadata_GetPinnedURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		expectedURL   string
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:        "valid URL",
+			url:         "http://example.com",
+			expectedURL: "http://example.com",
+			expectError: false,
+		},
+		{
+			name:        "empty URL",
+			url:         "",
+			expectedURL: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := FileMetadata{}
+			gotURL, err := m.GetPinnedURL(tt.url)
+			if (err != nil) != tt.expectError {
+				t.Errorf("GetPinnedURL() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if gotURL != tt.expectedURL {
+				t.Errorf("GetPinnedURL() gotURL = %v, expectedURL %v", gotURL, tt.expectedURL)
+			}
+		})
+	}
+}
+
+func TestDirectoryMetadata_GetPinnedURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		expectedURL   string
+		expectError   bool
+		expectedError string
+	}{
+		{
+			name:        "properly structured file path",
+			url:         "file:///path/to/policy",
+			expectedURL: "file:///path/to/policy",
+			expectError: false,
+		},
+		{
+			name:          "empty file path",
+			url:           "",
+			expectedURL:   "",
+			expectError:   true,
+			expectedError: "empty URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := DirectoryMetadata{}
+			gotURL, err := m.GetPinnedURL(tt.url)
+			if tt.expectError && err != nil {
+				if err.Error() != tt.expectedError {
+					t.Errorf("GetPinnedURL() error = %v, expectedError %v", err, tt.expectedError)
+				}
+				return
+			}
+			if gotURL != tt.expectedURL {
+				t.Errorf("GetPinnedURL() gotURL = %v, expectedURL %v", gotURL, tt.expectedURL)
+			}
+		})
+	}
+}

--- a/metadata/git/git.go
+++ b/metadata/git/git.go
@@ -35,6 +35,11 @@
 //	map[size:1024 path:/path/to/file.txt timestamp:2022-01-01 12:00:00 +0000 UTC commits:[{...}] path: size:0 timestamp:0001-01-01 00:00:00 +0000 UTC]
 package git
 
+import (
+	"fmt"
+	"strings"
+)
+
 // GitMetadata is a struct that represents the metadata of a git repository.
 // It has fields for size, path, timestamp, and commits.
 type GitMetadata struct {
@@ -49,4 +54,17 @@ func (m GitMetadata) Get() map[string]any {
 
 func (m GitMetadata) GetLatestCommit() string {
 	return m.LatestCommit
+}
+
+func (m GitMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	if m.LatestCommit == "" {
+		return "", fmt.Errorf("latest commit not set")
+	}
+	for _, scheme := range []string{"git::", "git://", "https://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return strings.SplitN("git://"+u, "?ref=", 2)[0] + "?ref=" + m.LatestCommit, nil
 }

--- a/metadata/git/git_test.go
+++ b/metadata/git/git_test.go
@@ -16,6 +16,7 @@
 package git
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -32,7 +33,7 @@ func TestGitMetadata_Get(t *testing.T) {
 	}
 	result := metadata.Get()
 
-	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedResult, result, fmt.Sprintf("expected: %v, got: %v", expectedResult, result))
 }
 
 // TestGetLatestCommit tests the GetLatestCommit method.
@@ -44,5 +45,76 @@ func TestGitMetadata_GetLatestCommit(t *testing.T) {
 	expectedResult := metadata.LatestCommit
 	result := metadata.GetLatestCommit()
 
-	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, expectedResult, result, fmt.Sprintf("expected: %v, got: %v", expectedResult, result))
+}
+
+func TestGetPinnedUrl(t *testing.T) {
+	goodMetadata := GitMetadata{
+		LatestCommit: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+	badMetadata := GitMetadata{}
+
+	tests := []struct {
+		name          string
+		url           string
+		expectedURL   string
+		expectError   bool
+		expectedError string
+		metadata      GitMetadata
+	}{
+		{
+			name:        "valid URL with git:// scheme",
+			url:         "git://example.com/org/repo.git",
+			expectedURL: "git://example.com/org/repo.git?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL with git:: scheme",
+			url:         "git::example.com/org/repo.git",
+			expectedURL: "git://example.com/org/repo.git?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL with https:// scheme",
+			url:         "https://example.com/org/repo.git",
+			expectedURL: "git://example.com/org/repo.git?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL without .git extension",
+			url:         "git://example.com/org/repo",
+			expectedURL: "git://example.com/org/repo?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:          "invalid URL",
+			url:           "",
+			expectedURL:   "git://example.com/org/repo?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError:   true,
+			expectedError: "empty URL",
+			metadata:      goodMetadata,
+		},
+		{
+			name:          "valid URL with empty metadata",
+			url:           "git://example.com/org/repo.git",
+			expectedURL:   "git://example.com/org/repo.git?ref=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expectError:   true,
+			expectedError: "latest commit not set",
+			metadata:      badMetadata,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.metadata.GetPinnedURL(tt.url)
+			if tt.expectError && err != nil {
+				assert.Equal(t, err.Error(), tt.expectedError, fmt.Sprintf("GetPinnedURL() error = %v, expectedError %v", err, tt.expectedError))
+				return
+			}
+			assert.Equal(t, result, tt.expectedURL, fmt.Sprintf("GetPinnedURL() gotURL = %v, expectedURL %v", result, tt.expectedURL))
+		})
+	}
 }

--- a/metadata/http/http.go
+++ b/metadata/http/http.go
@@ -16,6 +16,8 @@
 
 package http
 
+import "fmt"
+
 type HTTPMetadata struct {
 	StatusCode    int
 	ContentLength int64
@@ -30,4 +32,11 @@ func (m HTTPMetadata) Get() map[string]any {
 		"destination":   m.Destination,
 		"headers":       m.Headers,
 	}
+}
+
+func (m HTTPMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	return u, nil
 }

--- a/metadata/http/http_test.go
+++ b/metadata/http/http_test.go
@@ -45,3 +45,40 @@ func TestHTTPMetadata_Get(t *testing.T) {
 		t.Errorf("unexpected result: got %v, want %v", result, expected)
 	}
 }
+
+func TestFileMetadata_GetPinnedURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		url           string
+		expectedURL   string
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name:        "valid URL",
+			url:         "http://example.com",
+			expectedURL: "http://example.com",
+			expectError: false,
+		},
+		{
+			name:        "empty URL",
+			url:         "",
+			expectedURL: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := HTTPMetadata{}
+			gotURL, err := m.GetPinnedURL(tt.url)
+			if (err != nil) != tt.expectError {
+				t.Errorf("GetPinnedURL() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if gotURL != tt.expectedURL {
+				t.Errorf("GetPinnedURL() gotURL = %v, expectedURL %v", gotURL, tt.expectedURL)
+			}
+		})
+	}
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -23,4 +23,5 @@ package metadata
 // Metadata is an interface that all metadata types will satisfy.
 type Metadata interface {
 	Get() map[string]any // Example method; adjust according to actual use cases.
+	GetPinnedURL(string) (string, error)
 }

--- a/metadata/oci/oci.go
+++ b/metadata/oci/oci.go
@@ -16,6 +16,11 @@
 
 package oci
 
+import (
+	"fmt"
+	"strings"
+)
+
 type OCIMetadata struct {
 	Digest string
 }
@@ -29,4 +34,21 @@ func (o OCIMetadata) Get() map[string]any {
 // GetDigest returns the digest of the artifact.
 func (o OCIMetadata) GetDigest() string {
 	return o.Digest
+}
+
+func (o OCIMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	if o.Digest == "" {
+		return "", fmt.Errorf("image digest not set")
+	}
+	for _, scheme := range []string{"oci::", "oci://", "https://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	parts := strings.Split(u, "@")
+	if len(parts) > 1 {
+		u = parts[0]
+	}
+	return fmt.Sprintf("oci://%s@%s", u, o.Digest), nil
 }

--- a/metadata/oci/oci_test.go
+++ b/metadata/oci/oci_test.go
@@ -17,6 +17,7 @@
 package oci
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -39,4 +40,83 @@ func TestOCIMetadata_GetDigest(t *testing.T) {
 	expected := "fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f"
 	result := o.GetDigest()
 	assert.Equal(t, expected, result, "Expected GetDigest() to return %s, but got %s", expected, result)
+}
+
+func TestGetPinnedUrl(t *testing.T) {
+	goodMetadata := OCIMetadata{
+		Digest: "SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+	}
+	badMetadata := OCIMetadata{}
+
+	tests := []struct {
+		name          string
+		url           string
+		expectedURL   string
+		expectError   bool
+		expectedError string
+		metadata      OCIMetadata
+	}{
+		{
+			name:        "valid URL with oci:// scheme",
+			url:         "oci://example.com/org/repo",
+			expectedURL: "oci://example.com/org/repo@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL with oci:: scheme",
+			url:         "oci://example.com/org/repo",
+			expectedURL: "oci://example.com/org/repo@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+
+		{
+			name:        "valid URL with oci:// scheme and tag",
+			url:         "oci://example.com/org/repo:latest",
+			expectedURL: "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL with oci:: scheme and tag",
+			url:         "oci://example.com/org/repo:latest",
+			expectedURL: "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:        "valid URL with oci:: scheme, tag, and digest",
+			url:         "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectedURL: "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError: false,
+			metadata:    goodMetadata,
+		},
+		{
+			name:          "invalid URL",
+			url:           "",
+			expectedURL:   "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError:   true,
+			expectedError: "empty URL",
+			metadata:      goodMetadata,
+		},
+		{
+			name:          "valid URL with empty metadata",
+			url:           "oci://example.com/org/repo:latest",
+			expectedURL:   "oci://example.com/org/repo:latest@SHA256:fa93b01658e3a5a1686dc3ae55f170d8de487006fb53a28efcd12ab0710a2e5f",
+			expectError:   true,
+			expectedError: "image digest not set",
+			metadata:      badMetadata,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.metadata.GetPinnedURL(tt.url)
+			if tt.expectError && err != nil {
+				assert.Equal(t, err.Error(), tt.expectedError, fmt.Sprintf("GetPinnedURL() error = %v, expectedError %v", err, tt.expectedError))
+				return
+			}
+			assert.Equal(t, result, tt.expectedURL, fmt.Sprintf("GetPinnedURL() gotURL = %v, expectedURL %v", result, tt.expectedURL))
+		})
+	}
 }


### PR DESCRIPTION
This commit adds a GetPinnedURL which returns the provided URL with the git SHA for the latest commit or the OCI image digest.