### PR TITLE
FIX GetPinnedURL functions

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -88,6 +88,7 @@ func TestClassifyURI(t *testing.T) {
 		expected URIType
 	}{
 		{input: "git::git@github.com:user/repo.git", expected: GitURI},
+		{input: "git://github.com/user/repo.git//policiy/lib", expected: GitURI},
 		{input: "git@github.com:user/repo.git", expected: GitURI},
 		{input: "http::https://github.com/user/repo.git", expected: HTTPURI},
 		{input: "file::/home/user/file.txt", expected: FileURI},
@@ -113,7 +114,7 @@ func TestClassifyURI(t *testing.T) {
 	for _, tc := range testCases {
 		actual, err := ClassifyURI(tc.input)
 		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
+			t.Errorf("Unexpected error for %s: %v", tc.input, err)
 		}
 		if actual != tc.expected {
 			t.Errorf("Expected ClassifyURI(%s) to return %s, but got %s", tc.input, tc.expected, actual)

--- a/metadata/file/file.go
+++ b/metadata/file/file.go
@@ -42,6 +42,7 @@ package file
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -69,9 +70,12 @@ func (m *FileMetadata) Get() map[string]any {
 
 func (m FileMetadata) GetPinnedURL(u string) (string, error) {
 	if len(u) == 0 {
-		return "", fmt.Errorf("empty URL")
+		return "", fmt.Errorf("empty file path")
 	}
-	return u, nil
+	for _, scheme := range []string{"file::", "file://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return "file::" + u, nil
 }
 
 func (m *DirectoryMetadata) Get() map[string]any {
@@ -86,5 +90,8 @@ func (m DirectoryMetadata) GetPinnedURL(u string) (string, error) {
 	if len(u) == 0 {
 		return "", fmt.Errorf("empty file path")
 	}
-	return u, nil
+	for _, scheme := range []string{"file::", "file://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return "file::" + u, nil
 }

--- a/metadata/file/file_test.go
+++ b/metadata/file/file_test.go
@@ -18,6 +18,8 @@ package file
 import (
 	"testing"
 	"time"
+
+	"github.com/enterprise-contract/go-gather/metadata"
 )
 
 func TestFileMetadata_Get(t *testing.T) {
@@ -91,9 +93,9 @@ func TestFileMetadata_GetPinnedURL(t *testing.T) {
 		expectedError error
 	}{
 		{
-			name:        "valid URL",
-			url:         "http://example.com",
-			expectedURL: "http://example.com",
+			name:        "valid file URI",
+			url:         "file:///path/to/policy",
+			expectedURL: "file::/path/to/policy",
 			expectError: false,
 		},
 		{
@@ -118,7 +120,60 @@ func TestFileMetadata_GetPinnedURL(t *testing.T) {
 		})
 	}
 }
+func TestFileMetadata_GetPinnedUrl(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		metadata metadata.Metadata
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "With no prefix",
+			url:      "/path/to/policy.yaml",
+			metadata: &FileMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With file::",
+			url:      "file::/path/to/policy.yaml",
+			metadata: &FileMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With file://",
+			url:      "file:///path/to/policy.yaml",
+			metadata: &FileMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With emmpty file path",
+			url:      "",
+			metadata: &FileMetadata{},
+			expected: "",
+			hasError: true,
+		},
+	}
 
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run tests in parallel where possible
+
+			got, err := tc.metadata.GetPinnedURL(tc.url)
+			if (err != nil) != tc.hasError {
+				t.Errorf("GetPinnedURL() \nerror = %v, \nexpected error = %v", err, tc.hasError)
+				t.Fatalf("GetPinnedURL() \nerror = %v, \nexpected error = %v", err, tc.hasError)
+			}
+			if got != tc.expected {
+				t.Errorf("GetPinnedURL() = %q\ninput = %q\nexpected = %q\ngot = %q", got, tc.url, tc.expected, got)
+			}
+		})
+	}
+}
 func TestDirectoryMetadata_GetPinnedURL(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -130,7 +185,7 @@ func TestDirectoryMetadata_GetPinnedURL(t *testing.T) {
 		{
 			name:        "properly structured file path",
 			url:         "file:///path/to/policy",
-			expectedURL: "file:///path/to/policy",
+			expectedURL: "file::/path/to/policy",
 			expectError: false,
 		},
 		{
@@ -138,7 +193,7 @@ func TestDirectoryMetadata_GetPinnedURL(t *testing.T) {
 			url:           "",
 			expectedURL:   "",
 			expectError:   true,
-			expectedError: "empty URL",
+			expectedError: "empty file path",
 		},
 	}
 
@@ -154,6 +209,60 @@ func TestDirectoryMetadata_GetPinnedURL(t *testing.T) {
 			}
 			if gotURL != tt.expectedURL {
 				t.Errorf("GetPinnedURL() gotURL = %v, expectedURL %v", gotURL, tt.expectedURL)
+			}
+		})
+	}
+}
+func TestDirectoryMetadata_GetPinnedUrl(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		metadata metadata.Metadata
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "With no prefix",
+			url:      "/path/to/policy.yaml",
+			metadata: &DirectoryMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With file::",
+			url:      "file::/path/to/policy.yaml",
+			metadata: &DirectoryMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With file://",
+			url:      "file:///path/to/policy.yaml",
+			metadata: &DirectoryMetadata{},
+			expected: "file::/path/to/policy.yaml",
+			hasError: false,
+		},
+		{
+			name:     "With emmpty file path",
+			url:      "",
+			metadata: &DirectoryMetadata{},
+			expected: "",
+			hasError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run tests in parallel where possible
+
+			got, err := tc.metadata.GetPinnedURL(tc.url)
+			if (err != nil) != tc.hasError {
+				t.Errorf("GetPinnedURL() \nerror = %v, \nexpected error = %v", err, tc.hasError)
+				t.Fatalf("GetPinnedURL() \nerror = %v, \nexpected error = %v", err, tc.hasError)
+			}
+			if got != tc.expected {
+				t.Errorf("GetPinnedURL() = %q\ninput = %q\nexpected = %q\ngot = %q", got, tc.url, tc.expected, got)
 			}
 		})
 	}

--- a/metadata/file/go.mod
+++ b/metadata/file/go.mod
@@ -1,3 +1,5 @@
 module github.com/enterprise-contract/go-gather/metadata/file
 
 go 1.22.5
+
+require github.com/enterprise-contract/go-gather/metadata v0.0.2

--- a/metadata/file/go.sum
+++ b/metadata/file/go.sum
@@ -1,0 +1,2 @@
+github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
+github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=

--- a/metadata/git/git.go
+++ b/metadata/git/git.go
@@ -66,5 +66,8 @@ func (m GitMetadata) GetPinnedURL(u string) (string, error) {
 	for _, scheme := range []string{"git::", "git://", "https://"} {
 		u = strings.TrimPrefix(u, scheme)
 	}
-	return strings.SplitN("git://"+u, "?ref=", 2)[0] + "?ref=" + m.LatestCommit, nil
+	if strings.HasPrefix(u, "git@") {
+		u = strings.Replace(strings.Split(u, "git@")[1], ":", "/", 1)
+	}
+	return "git::" + strings.SplitN(u, "?ref=", 2)[0] + "?ref=" + m.LatestCommit, nil
 }

--- a/metadata/git/go.mod
+++ b/metadata/git/go.mod
@@ -2,7 +2,10 @@ module github.com/enterprise-contract/go-gather/metadata/git
 
 go 1.22.5
 
-require github.com/go-git/go-git/v5 v5.12.0
+require (
+	github.com/enterprise-contract/go-gather/metadata v0.0.2
+	github.com/go-git/go-git/v5 v5.12.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/metadata/git/go.sum
+++ b/metadata/git/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
+github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
 github.com/go-git/go-git/v5 v5.12.0 h1:7Md+ndsjrzZxbddRDZjF14qK+NN56sy6wkqaVrjZtys=
 github.com/go-git/go-git/v5 v5.12.0/go.mod h1:FTM9VKtnI2m65hNI/TenDDDnUf2Q9FHnXYjuz9i5OEY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/metadata/http/http.go
+++ b/metadata/http/http.go
@@ -16,7 +16,10 @@
 
 package http
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type HTTPMetadata struct {
 	StatusCode    int
@@ -38,5 +41,8 @@ func (m HTTPMetadata) GetPinnedURL(u string) (string, error) {
 	if len(u) == 0 {
 		return "", fmt.Errorf("empty URL")
 	}
-	return u, nil
+	for _, scheme := range []string{"http://", "https://", "http::"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return "http::" + u, nil
 }

--- a/metadata/http/http_test.go
+++ b/metadata/http/http_test.go
@@ -57,7 +57,7 @@ func TestFileMetadata_GetPinnedURL(t *testing.T) {
 		{
 			name:        "valid URL",
 			url:         "http://example.com",
-			expectedURL: "http://example.com",
+			expectedURL: "http::example.com",
 			expectError: false,
 		},
 		{

--- a/metadata/oci/go.mod
+++ b/metadata/oci/go.mod
@@ -2,7 +2,10 @@ module github.com/enterprise-contract/go-gather/metadata/oci
 
 go 1.22.5
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/enterprise-contract/go-gather/metadata v0.0.2
+	github.com/stretchr/testify v1.9.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/metadata/oci/go.sum
+++ b/metadata/oci/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
+github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/metadata/oci/oci.go
+++ b/metadata/oci/oci.go
@@ -50,5 +50,5 @@ func (o OCIMetadata) GetPinnedURL(u string) (string, error) {
 	if len(parts) > 1 {
 		u = parts[0]
 	}
-	return fmt.Sprintf("oci://%s@%s", u, o.Digest), nil
+	return fmt.Sprintf("oci::%s@%s", u, o.Digest), nil
 }


### PR DESCRIPTION
This commit creates a uniform output from GetPinnedURL to return the parsed URL with metadata with the specific URL type prefix (git::, oci::, etc)

Updated tests to reflect these changes as well.

As part of this commit, the ClassifyURL() function was updated to remove unnecessary complexites around regex usage.