### PR TITLE
Make sure pinned file urls roundtrip

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -46,6 +46,8 @@ type FileGatherer struct{}
 // Gather copies a file or directory from the source path to the destination path.
 // It returns the metadata of the gathered file or directory and any error encountered.
 func (f *FileGatherer) Gather(ctx context.Context, source, destination string) (metadata.Metadata, error) {
+	source = strings.TrimPrefix(source, "file::")
+
 	// Parse the source URI
 	src, err := url.Parse(source)
 

--- a/gather/file/file_test.go
+++ b/gather/file/file_test.go
@@ -251,8 +251,8 @@ func TestFileGatherer_copyFile_CreateSaverError(t *testing.T) {
 	if err == nil {
 		t.Error("expected an error, but got nil")
 	}
-	if err.Error() != "failed to classify destination URI: unsupported protocol: ftp" {
-		t.Logf("Expected: %s, Got: %s", "failed to classify destination URI: unsupported protocol: ftp", err.Error())
+	if got, expected := err.Error(), "failed to classify destination URI: unsupported source protocol: ftp"; got != expected {
+		t.Logf("Expected: %s, Got: %s", expected, got)
 		t.Fail()
 	}
 
@@ -340,4 +340,34 @@ func TestFileGatherer_getFileSha_OpenFileError(t *testing.T) {
 		t.Fail()
 	}
 
+}
+
+func TestPinnedUrlRoundtrip(t *testing.T) {
+	// setup
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source")
+	if err := os.MkdirAll(source, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "file.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	file := &FileGatherer{}
+	destination := filepath.Join(tmp, "destination")
+	ctx := context.Background()
+	m, err := file.Gather(ctx, source, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pinned, err := m.GetPinnedURL(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = file.Gather(ctx, pinned, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/gather/file/go.mod
+++ b/gather/file/go.mod
@@ -5,8 +5,8 @@ go 1.22.5
 require (
 	github.com/enterprise-contract/go-gather v0.0.3
 	github.com/enterprise-contract/go-gather/expander v0.0.1
-	github.com/enterprise-contract/go-gather/metadata v0.0.2
-	github.com/enterprise-contract/go-gather/metadata/file v0.0.1
+	github.com/enterprise-contract/go-gather/metadata v0.0.3-0.20241015082844-9df651247f12
+	github.com/enterprise-contract/go-gather/metadata/file v0.0.2-0.20241015082844-9df651247f12
 	github.com/enterprise-contract/go-gather/saver v0.0.2
 )
 

--- a/gather/file/go.sum
+++ b/gather/file/go.sum
@@ -4,8 +4,12 @@ github.com/enterprise-contract/go-gather/expander v0.0.1 h1:CRJX7crqNyuuo82DtFby
 github.com/enterprise-contract/go-gather/expander v0.0.1/go.mod h1:bZ7oijDzlpY3gGc+H48YSsxbCEGxmsqQj+PxnYjtrjg=
 github.com/enterprise-contract/go-gather/metadata v0.0.2 h1:BxPXXZFjX7lrYnlJosPmvISgjF13HpawEtZTDxjnjcQ=
 github.com/enterprise-contract/go-gather/metadata v0.0.2/go.mod h1:m2HxByQBWZyc99HDs/Lqy7QzU9+XQ2tU0X/mzkCPgPw=
+github.com/enterprise-contract/go-gather/metadata v0.0.3-0.20241015082844-9df651247f12 h1:FN0K31S7Ebbhc4HfFKbIlSkxaCNDrv9rb2sxiOk74x4=
+github.com/enterprise-contract/go-gather/metadata v0.0.3-0.20241015082844-9df651247f12/go.mod h1:61zwrsbS85d0fEUtM34Rfdz07KhDSBfwnqxTLqzjoy4=
 github.com/enterprise-contract/go-gather/metadata/file v0.0.1 h1:DRhTGKRXFRh/FVn2LNX8yIJZHHYKc5x5260hnYxQ4DY=
 github.com/enterprise-contract/go-gather/metadata/file v0.0.1/go.mod h1:4PckwLejZstUEBp2QUAdQYQ0O+h5tijrs48j+7OY4OY=
+github.com/enterprise-contract/go-gather/metadata/file v0.0.2-0.20241015082844-9df651247f12 h1:a2g1SUSyMG+CsljBfwimzof6HZF3jfyDodsV0k3M+Yw=
+github.com/enterprise-contract/go-gather/metadata/file v0.0.2-0.20241015082844-9df651247f12/go.mod h1:PwGPhiuskbcewgVtxIh/Anv8RGgaON/WTWQFRM+Pw4E=
 github.com/enterprise-contract/go-gather/saver v0.0.2 h1:+XeeuEzglzBxlTRD0boIqac7v4zI7g2g2es74iVTXgM=
 github.com/enterprise-contract/go-gather/saver v0.0.2/go.mod h1:3f37v+I/EY8me7gaopGly107R7gqibR8UyBA3NgzMbo=
 github.com/enterprise-contract/go-gather/saver/file v0.0.1 h1:rLDMb7AW5kJLqRaKXazZroT8wfqy43tth6O6XLKY0MY=


### PR DESCRIPTION
The pinned file URL has a `file::` prefix, when provided to the
`url.Parse` such URLs will have an empty path. This strips the `file::`
prefix from the source URLs provided to the gather/file.