### PR TITLE
fix: Added missing "v" in tagFormat in .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,7 +2,7 @@
   "branches": [
     "main"
   ],
-  "tagFormat": "${version}",
+  "tagFormat": "v${version}",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
This commit added the missing "v" in the tagFormat in .releaserc. This should result in pkgs.go.com picking up the newly tagged versions of go-gather.