### PR TITLE
refactor: oci/internal/network.Hostname

### DIFF
--- a/gather/oci/internal/network/network.go
+++ b/gather/oci/internal/network/network.go
@@ -23,21 +23,23 @@ import (
 
 /* This code is sourced from the open-policy-agent/conftest project. */
 func Hostname(ref string) string {
-	ref = strings.TrimPrefix(ref, "oci://")
-
-	colon := strings.Index(ref, ":")
-	slash := strings.Index(ref, "/")
-
-	cut := colon
-	if colon == -1 || (colon > slash && slash != -1) {
-		cut = slash
-	}
-
-	if cut < 0 {
+	if ref == "" {
 		return ref
 	}
 
-	return ref[0:cut]
+	ref = strings.TrimPrefix(ref, "oci://")
+
+	slash := strings.IndexByte(ref, '/')
+	if slash > 0 {
+		ref = ref[0:slash]
+	}
+
+	host, _, err := net.SplitHostPort(ref)
+	if err == nil {
+		return host
+	}
+
+	return ref
 }
 
 func IsLoopback(host string) bool {

--- a/gather/oci/internal/network/network_test.go
+++ b/gather/oci/internal/network/network_test.go
@@ -1,0 +1,127 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import "testing"
+
+func TestHostname(t *testing.T) {
+	cases := []struct {
+		given    string
+		expected string
+	}{
+		{
+			given:    "example.com",
+			expected: "example.com",
+		},
+		{
+			given:    "example.com:12345",
+			expected: "example.com",
+		},
+		{
+			given:    "example.com/path",
+			expected: "example.com",
+		},
+		{
+			given:    "oci://example.com",
+			expected: "example.com",
+		},
+		{
+			given:    "oci://example.com:12345",
+			expected: "example.com",
+		},
+		{
+			given:    "oci://example.com:12345",
+			expected: "example.com",
+		},
+		{
+			given:    "oci://example.com:12345/path",
+			expected: "example.com",
+		},
+		{
+			given:    "example.com//path",
+			expected: "example.com",
+		},
+		{
+			given:    "example.com/p1/p2/p3",
+			expected: "example.com",
+		},
+		{
+			given:    "localhost",
+			expected: "localhost",
+		},
+		{
+			given:    "localhost:12345",
+			expected: "localhost",
+		},
+		{
+			given:    "localhost/path",
+			expected: "localhost",
+		},
+		{
+			given:    "localhost:12345/path",
+			expected: "localhost",
+		},
+		{
+			given:    "1.2.3.4",
+			expected: "1.2.3.4",
+		},
+		{
+			given:    "1.2.3.4:12345",
+			expected: "1.2.3.4",
+		},
+		{
+			given:    "oci://1.2.3.4",
+			expected: "1.2.3.4",
+		},
+		{
+			given:    "oci://1.2.3.4:12345",
+			expected: "1.2.3.4",
+		},
+		{
+			given:    "::1",
+			expected: "::1",
+		},
+		{
+			given:    "[::1]:12345",
+			expected: "::1",
+		},
+		{
+			given:    "[::1]:12345/path",
+			expected: "::1",
+		},
+		{
+			given:    "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+			expected: "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+		{
+			given:    "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345",
+			expected: "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+		{
+			given:    "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:12345/path",
+			expected: "2001:db8:85a3:8d3:1319:8a2e:370:7348",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.given, func(t *testing.T) {
+			if got, expected := Hostname(c.given), c.expected; got != expected {
+				t.Errorf("Hostname(%q) = %q, expected %q", c.given, got, c.expected)
+			}
+		})
+	}
+}

--- a/gather/oci/internal/registry/client.go
+++ b/gather/oci/internal/registry/client.go
@@ -34,8 +34,10 @@ func SetupClient(repository *remote.Repository, transport http.RoundTripper) err
 	registry := repository.Reference.Host()
 
 	// If `--tls=false` was provided or accessing the registry via loopback with
-	// `--tls` flag was not provided
-	if !viper.GetBool("tls") || (network.IsLoopback(network.Hostname(registry)) && !viper.IsSet("tls")) {
+	// `--tls` flag was not set to true
+	forceTLS := viper.IsSet("tls") && viper.GetBool("tls")
+	forcePlain := viper.IsSet("tls") && !viper.GetBool("tls")
+	if forcePlain || (network.IsLoopback(network.Hostname(registry)) && !forceTLS) {
 		// Docker by default accesses localhost using plaintext HTTP
 		repository.PlainHTTP = true
 	}

--- a/gather/oci/internal/registry/client_test.go
+++ b/gather/oci/internal/registry/client_test.go
@@ -1,0 +1,112 @@
+// Copyright The Enterprise Contract Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/spf13/viper"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+func TestRepositoryPlainHTTP(t *testing.T) {
+	no := false
+	yes := true
+	cases := []struct {
+		name      string
+		flag      *bool
+		registry  string
+		plainHTTP bool
+	}{
+		{
+			name:      "tls=false",
+			flag:      &no,
+			plainHTTP: true,
+		},
+		{
+			name:      "tls=true",
+			flag:      &yes,
+			plainHTTP: false,
+		},
+		{
+			name:      "hostname=localhost:5000",
+			registry:  "localhost:5000",
+			plainHTTP: true,
+		},
+		{
+			name:      "hostname=[::1]:5000",
+			registry:  "[::1]:5000",
+			plainHTTP: true,
+		},
+		{
+			name:      "hostname=localhost:5000,tls=true",
+			flag:      &yes,
+			registry:  "localhost:5000",
+			plainHTTP: false,
+		},
+		{
+			name:      "hostname=[::1]:5000,tls=true",
+			flag:      &yes,
+			registry:  "[::1]:5000",
+			plainHTTP: false,
+		},
+		{
+			name:      "hostname=quay.io",
+			registry:  "quay.io",
+			plainHTTP: false,
+		},
+		{
+			name:      "hostname=quay.io,tls=false",
+			flag:      &no,
+			registry:  "quay.io",
+			plainHTTP: true,
+		},
+		{
+			name:      "hostname=quay.io,tls=false",
+			flag:      &yes,
+			registry:  "quay.io",
+			plainHTTP: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := remote.Repository{}
+
+			if c.registry != "" {
+				r.Reference = registry.Reference{Registry: c.registry}
+			}
+
+			viper.AutomaticEnv()
+			viper.SetEnvPrefix("TEST")
+			if c.flag != nil {
+				t.Setenv("TEST_TLS", strconv.FormatBool(*c.flag))
+			}
+
+			err := SetupClient(&r, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if expected, got := c.plainHTTP, r.PlainHTTP; expected != got {
+				t.Errorf("PlainHTTP = %v, expected %v", got, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refactors the `Hostname` function to support IPv6 references containing
port numbers. Adds tests.