### PR TITLE
ADD `GetPinnedUrl()` function

### DIFF
--- a/gather/file/file.go
+++ b/gather/file/file.go
@@ -129,6 +129,16 @@ func (f *FSMetadata) Get() interface{} {
 	return f
 }
 
+func (f FSMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty file path")
+	}
+	for _, scheme := range []string{"file::", "file://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return "file::" + u, nil
+}
+
 // save copies from a filesystem source to a filesystem destination.
 // If append is true, the file will be appended to the destination.
 func (f *FileSaver) save(ctx context.Context, source string, destination string, append bool) (metadata.Metadata, error) {

--- a/gather/git/git.go
+++ b/gather/git/git.go
@@ -145,6 +145,22 @@ func (g *GitMetadata) Get() interface{} {
 	return g
 }
 
+func (g GitMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	if g.LatestCommit == "" {
+		return "", fmt.Errorf("latest commit not set")
+	}
+	for _, scheme := range []string{"git::", "git://", "https://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	if strings.HasPrefix(u, "git@") {
+		u = strings.Replace(strings.Split(u, "git@")[1], ":", "/", 1)
+	}
+	return "git::" + strings.SplitN(u, "?ref=", 2)[0] + "?ref=" + g.LatestCommit, nil
+}
+
 // NewSSHAgentAuth returns an AuthMethod that uses the SSH agent for authentication.
 // It uses the specified user as the username for authentication.
 func (r *RealSSHAuthenticator) NewSSHAgentAuth(user string) (transport.AuthMethod, error) {

--- a/gather/http/http.go
+++ b/gather/http/http.go
@@ -158,6 +158,16 @@ func (h *HTTPMetadata) Get() interface{} {
 	return h
 }
 
+func (h HTTPMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	for _, scheme := range []string{"http://", "https://", "http::"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	return "http::" + u, nil
+}
+
 func init() {
 	gather.RegisterGatherer(&HTTPGatherer{})
 }

--- a/gather/oci/oci.go
+++ b/gather/oci/oci.go
@@ -128,6 +128,23 @@ func (o *OCIMetadata) GetDigest() string {
 	return o.Digest
 }
 
+func (o OCIMetadata) GetPinnedURL(u string) (string, error) {
+	if len(u) == 0 {
+		return "", fmt.Errorf("empty URL")
+	}
+	if o.Digest == "" {
+		return "", fmt.Errorf("image digest not set")
+	}
+	for _, scheme := range []string{"oci::", "oci://", "https://"} {
+		u = strings.TrimPrefix(u, scheme)
+	}
+	parts := strings.Split(u, "@")
+	if len(parts) > 1 {
+		u = parts[0]
+	}
+	return fmt.Sprintf("oci::%s@%s", u, o.Digest), nil
+}
+
 func ociURLParse(source string) string {
 	if strings.Contains(source, "::") {
 		source = strings.Split(source, "::")[1]

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -18,4 +18,5 @@ package metadata
 
 type Metadata interface {
 	Get() interface{}
+	GetPinnedURL(string) (string, error)
 }


### PR DESCRIPTION
These commits introduce the `GetPinnedUrl()` function to the `Metadata` interface along with introducing the implementation for the various Gatherer metadata types (file, git, http, oci).