### PR TITLE
bug(gather): Fix `Matcher` function for Gatherers

### DIFF
--- a/gather/git/git.go
+++ b/gather/git/git.go
@@ -61,13 +61,20 @@ type SSHAuthenticator interface {
 type RealSSHAuthenticator struct{}
 
 func (g *GitGatherer) Matcher(uri string) bool {
-	terms := []string{"git@", "git://", "git::", ".git", "github.com", "gitlab.com", "bitbucket.org"}
-	for _, term := range terms {
+	prefixes := []string{"git@", "git://", "git::"}
+	for _, term := range prefixes {
+		if strings.HasPrefix(uri, term) {
+			return true
+		}
+	}
+
+	for _, term := range []string{"github.com", "gitlab.com", "bitbucket.org"} {
 		if strings.Contains(uri, term) {
 			return true
 		}
 	}
-	return false
+
+	return strings.HasSuffix(uri, ".git")
 }
 
 func (g *GitGatherer) Gather(ctx context.Context, src, dst string) (metadata.Metadata, error) {

--- a/gather/git/git_test.go
+++ b/gather/git/git_test.go
@@ -42,6 +42,7 @@ func TestGitGatherer_Matcher(t *testing.T) {
 		{"git protocol slash slash", "git://github.com/org/repo.git", true},
 		{"dot git suffix", "https://github.com/org/repo.git", true},
 		{"match github.com", "github.com/org/repo", true},
+		{"not match githubusercontent.com", "https://raw.githubusercontent.com/foo/bar", false},
 		{"other prefix", "svn://some/repo", false},
 	}
 

--- a/gather/http/http.go
+++ b/gather/http/http.go
@@ -147,7 +147,7 @@ func (h *HTTPGatherer) Gather(ctx context.Context, rawSource, dst string) (metad
 func (h *HTTPGatherer) Matcher(uri string) bool {
 	prefixes := []string{"http://", "https://"}
 	for _, prefix := range prefixes {
-		if strings.HasPrefix(uri, prefix) && !(strings.Contains(uri, "github") || strings.Contains(uri, "gitlab") || strings.Contains(uri, "bitbucket")) {
+		if strings.HasPrefix(uri, prefix) && !(strings.Contains(uri, "github.com") || strings.Contains(uri, "gitlab.com") || strings.Contains(uri, "bitbucket.com")) {
 			return true
 		}
 	}


### PR DESCRIPTION
This commit fixes the checks in the `GitGather.Matcher()` function to more accurately detect git URLs.

This commit adds specific checks for `github.com`, `gitlab.com`, and `bitbucket.com` in the `HTTPGatherer.Matcher()` function to ensure that they aren't matched by the HTTP gatherer.