### PR TITLE
fix(git-matcher) Fix git matcher failure.

### DIFF
--- a/gather/git/git.go
+++ b/gather/git/git.go
@@ -68,6 +68,12 @@ func (g *GitGatherer) Matcher(uri string) bool {
 		}
 	}
 
+	// check if we have any magic prefixes (::) in the URL
+	// If we do, we don't want to match it as a git URL.
+	if strings.Contains(uri, "::") {
+		return false
+	}
+
 	for _, term := range []string{"github.com", "gitlab.com", "bitbucket.org"} {
 		if strings.Contains(uri, term) {
 			return true

--- a/gather/git/git_test.go
+++ b/gather/git/git_test.go
@@ -40,6 +40,7 @@ func TestGitGatherer_Matcher(t *testing.T) {
 		{"git@ domain", "git@github.com:org/repo.git", true},
 		{"git protocol double colon", "git::github.com/org/repo", true},
 		{"git protocol slash slash", "git://github.com/org/repo.git", true},
+		{"unknown protocol double colon", "s3::github.com/org/repo", false},
 		{"dot git suffix", "https://github.com/org/repo.git", true},
 		{"match github.com", "github.com/org/repo", true},
 		{"not match githubusercontent.com", "https://raw.githubusercontent.com/foo/bar", false},


### PR DESCRIPTION
This commit updates the `git.Matcher` method to ensure that it doesn't match if we have unknown "magic" protocols (those which use the :: syntax) in the URL.

Ref: EC-960